### PR TITLE
Added initial VRI-ON support

### DIFF
--- a/app/services/general_registration_search.rb
+++ b/app/services/general_registration_search.rb
@@ -1,0 +1,28 @@
+class GeneralRegistrationSearch
+
+  def self.perform(search_query, config)
+    q = {} # todo search_query -> URL params
+    uri = URI("#{config['url']}?#{q.to_query}")
+    result = nil
+
+    begin
+      raise 'generic lookup service is not configured' if config['url'].blank?
+
+      LookupApi.parse_uri_without_timeout('not_used_method_name', uri) do |response|
+        if response.code == '200'
+          result = JSON.parse(response.body)
+        else
+          raise LookupApi::SearchError.new('timeout') # TODO locale key to show others errors
+        end
+      end
+    rescue Timeout::Error
+      Rails.logger.error "LOOKUP: timeout URL: #{uri}" if AppConfig['api_debug_logging']
+      ErrorLogRecord.log("LOOKUP: timeout", uri: uri)
+      LogRecord.lookup_timeout(uri)
+
+      raise LookupApi::LookupTimeout
+    end
+
+    VriAdapter.new(result).to_registration
+  end
+end

--- a/app/services/registration_search.rb
+++ b/app/services/registration_search.rb
@@ -15,19 +15,8 @@ class RegistrationSearch < AbstractRegistrationSearch
       else
         xml = search_by_data(search_query.ssn4, search_query.locality, search_query.dob, search_query.first_name, search_query.last_name)
       end
-
-    else 
-      if SearchController.helpers.lookup_service_config['debug']
-        vid = '123123124' #search_query.id_document_number
-        
-        if SearchController.helpers.lookup_service_config['street_name'] && search_query.street_name.downcase == 'main'
-          return self.sample_record(vid)
-        else
-          raise RecordNotFound
-        end
-      else
-        raise 'generic lookup service not implemented'
-      end
+    else
+      return GeneralRegistrationSearch.perform(@search_query, SearchController.helpers.lookup_service_config)
     end
     
     DebugLogging.log_response_to_file("eml330", xml)

--- a/app/services/vri_adapter.rb
+++ b/app/services/vri_adapter.rb
@@ -1,0 +1,150 @@
+class VriAdapter
+  # sample match response
+  # VRI_ON_RESPONSE =
+  #   {
+  #     :voter_records_response => {
+  #       :registration_success => {
+  #         :action => "registration-matched",
+  #         :voter_registration => {
+  #           :registration_address => {
+  #             :numbered_thoroughfare_address => {
+  #               :complete_address_number => {:address_number => "123"},
+  #               :complete_street_name => {
+  #                 :street_name => "Walnut",
+  #                 :street_name_post_type => "Avenue",
+  #                 :street_name_post_directional => "Northwest"
+  #               },
+  #               :complete_sub_address => {
+  #                   :sub_address_type => "APT",
+  #                   :sub_address => "#2"
+  #               },
+  #               :complete_place_names => [
+  #                   {
+  #                     :place_name_type => "MunicipalJurisdiction",
+  #                     :place_name_value => "Stittsville"
+  #                   },
+  #                   {
+  #                     :place_name_type => "County",
+  #                     :place_name_value => "Carleton"
+  #                   }
+  #               ],
+  #               :state => "Ontario",
+  #               :zip_code => "K2M3C4"
+  #             }
+  #           },
+  #           :registration_address_is_mailing_address => true,
+  #           :name => {
+  #             :first_name => "Aaron",
+  #             :last_name => "Huttner",
+  #             :middle_name => "Bernard",
+  #             :title_prefix => "Mr",
+  #             :title_suffix => "Jr"
+  #           },
+  #           :gender => "male",
+  #           :voter_ids => [
+  #               {
+  #                 :type => "drivers_license",
+  #                 :attest_no_such_id => false
+  #               },
+  #               {
+  #                 :type => "other",
+  #                 :othertype => "elector_id",
+  #                 :string_value => "1234",
+  #                 :attest_no_such_id => false
+  #               }
+  #           ],
+  #           :voter_classifications => [
+  #               {:Assertion => "true", :Type => "Other", :OtherType => "citizen"},
+  #               {:Assertion => "true", :Type => "Other", :OtherType => "resident-of-ontario"}
+  #           ],
+  #           :contact_methods => [
+  #             {:type => "phone", :value => "555-555-5555", :capabilities => ["voice", "fax", "sms"]},
+  #             {:type => "email", :value => "xyz@gmail.com"}
+  #           ]
+  #         }
+  #       }
+  #     }
+  #   }.stringify_keys!
+
+  def to_registration
+    Registration.new(data: {
+        :voter_id => voter_id,
+        :current_residence => "in", # TODO analyze voter_classifications # affects `currently_overseas?` and showing mail address
+        :first_name => source_data.name.first_name,
+        :middle_name => source_data.name.middle_name,
+        :last_name => source_data.name.last_name,
+        :name_suffix => source_data.name.title_suffix,
+        :phone => phone,
+        :gender => gender,
+        # :dob => Date.new(1950, 11, 06),             # TODO ??? ## shown at registrations/show
+        # :choose_party  =>  "1",                     # probably not shown at registrations/show
+        # :party => "Democratic Party",               # probably not shown at registrations/show
+        :vvr_address_1 => address_1,        # used in RegistrationDetailsPresenter.registration_address
+        :vvr_county_or_city => county,
+        # :vvr_town => "Queensberry",
+        :vvr_state => source_data.registration_address.numbered_thoroughfare_address.state,
+        # :vvr_zip5 => "24201",
+        # :vvr_zip4 => "2445",
+        # :vvr_is_rural => "0",
+        :ma_is_different => "0",                    # Hide Mailing Address
+        # :ma_address => "518 Vance St",
+        # :ma_city => "Queensberry",
+        # :ma_state => "VA",
+        # :ma_zip5 => "24201",
+        # :ma_zip4 => "2445",
+        # :pr_status => "0",                          # not shown at registrations/show
+        :is_confidential_address => "1",            # TODO affects address_confidentiality? and paperless_submission_allowed?
+        :ca_type => "TSC",
+        # :be_official => "1",                        # probably not shown at registrations/show
+        # :existing => true,
+        # :poll_locality => "BRUNSWICK COUNTY",       # TODO ??? # affects registrations/show
+        # :poll_precinct => "220 - RATCLIFFE",        # TODO ??? # affects registrations/show
+        # :poll_district => "FAIRFIELD DISTRICT",
+        # :districts => [["Congressional", ["09", "9th District"]], ["Senate", ["038", "38th District"]], ["State House", ["003", "3rd District"]], ["Local", ["", "SOUTHERN DISTRICT"]]],
+        # :past_elections => [["2007 November", "Absentee"]],
+        # :ob_eligible => true,
+        # :absentee_for_elections => ["Election 1", "Election 2"]
+    })
+  end
+
+  def initialize(vri_on_response)
+    # deep (recursive) conversion to OpenStruct
+    @source = JSON.parse(vri_on_response.to_json, object_class: OpenStruct)
+    raise LookupApi::RecordNotFound if not_found?
+  end
+
+  def voter_id
+    source_data.voter_ids.find { |x| x.othertype == 'elector_id' }.try(:string_value)
+  end
+
+  def phone
+    source_data.contact_methods.find {|x| x.type == 'phone' }.try(:value)
+  end
+
+  def gender
+    source_data.gender.try(:capitalize)
+  end
+
+  def address_1
+    [
+        source_data.registration_address.numbered_thoroughfare_address.complete_address_number.address_number,
+        source_data.registration_address.numbered_thoroughfare_address.complete_street_name.street_name
+    ].join(' ')
+
+  end
+
+  def county
+    source_data.registration_address.numbered_thoroughfare_address.complete_place_names.find{|x| x.place_name_type == 'County'}.try(:place_name_value)
+  end
+
+  def source_data
+    @source.voter_records_response.registration_success.voter_registration
+  end
+
+  private
+
+  def not_found?
+    success = @source.voter_records_response.registration_success
+    success.nil? || success.action != 'registration-matched'
+  end
+end

--- a/config/config_service.yml.ONsample
+++ b/config/config_service.yml.ONsample
@@ -16,6 +16,7 @@ lookup:
   enabled: true
   is_registration_first_step: true
   identification_document: false
+  url: https://vri-on-stub.herokuapp.com/lookup
 
 
   

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -32,6 +32,28 @@ describe SearchController do
       specify { assigns(:error).should be }
       it      { should render_template :error }
     end
+
+    context 'general search is set up' do
+      it 'invokes General Search' do
+        # can't fix SearchQuery conditional attributes, only one custom env can be set when classes are loaded
+        # so we fix consequences - valid? is always true
+        expect_any_instance_of(SearchQuery).to receive(:valid?).and_return(true)
+        expect(GeneralRegistrationSearch).to receive(:perform).and_return(FactoryGirl.create(:registration, :residential_voter))
+
+        # system PARTLY works right only if expected values are loaded from the config
+        # can't mock this due to SearchQuery design
+        expect(AppConfig['services']['lookup']['id_and_locality_style']).to be_false
+
+        post :create, locale: 'en', search_query: {
+            "first_name"=>"a",
+            "last_name"=>"a",
+            "street_number"=>"1",
+            "street_name"=>"main",
+            "street_type"=>"Street",
+            "date_of_birth"=>Date.new(1990,1,1)
+        }
+      end
+    end
   end
 
 end

--- a/spec/services/general_registration_search_spec.rb
+++ b/spec/services/general_registration_search_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe GeneralRegistrationSearch do
+
+  describe 'perform' do
+    subject { GeneralRegistrationSearch.perform(query, config)}
+    let(:query) { double }
+    let(:config) { { 'url' => 'url' } }
+    let(:adapter_mock) { double( to_registration: :registration) }
+
+    it 'passes result to VriAdapter' do
+      # how to mock URI('url') ?
+      expect(LookupApi).to receive(:parse_uri_without_timeout) # can't mock {yield :response} to get a side effect
+      expect(VriAdapter).to receive(:new).with(anything).and_return(adapter_mock)
+      expect(subject).to be_eql :registration
+    end
+  end
+end

--- a/spec/services/vri_adapter_spec.rb
+++ b/spec/services/vri_adapter_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+describe VriAdapter do
+
+  VRI_ON_MATCH_RESPONSE =
+    {
+      :voter_records_response => {
+        :registration_success => {
+          :action => "registration-matched",
+          :voter_registration => {
+            :registration_address => {
+              :numbered_thoroughfare_address => {
+                :complete_address_number => {:address_number => "123"},
+                :complete_street_name => {
+                  :street_name => "Walnut",
+                  :street_name_post_type => "Avenue",
+                  :street_name_post_directional => "Northwest"
+                },
+                :complete_sub_address => {
+                  :sub_address_type => "APT",
+                  :sub_address => "#2"
+                },
+                :complete_place_names => [
+                  {
+                    :place_name_type => "MunicipalJurisdiction",
+                    :place_name_value => "Stittsville"
+                  },
+                  {
+                    :place_name_type => "County",
+                    :place_name_value => "Carleton"
+                  }
+                ],
+                :state => "Ontario",
+                :zip_code => "K2M3C4"
+              }
+            },
+            :registration_address_is_mailing_address => true,
+            :name => {
+              :first_name => "Aaron",
+              :last_name => "Huttner",
+              :middle_name => "Bernard",
+              :title_prefix => "Mr",
+              :title_suffix => "Jr"
+            },
+            :gender => "male",
+            :voter_ids => [
+              {
+                :type => "drivers_license",
+                :attest_no_such_id => false
+              },
+              {
+                :type => "other",
+                :othertype => "elector_id",
+                :string_value => "1234",
+                :attest_no_such_id => false
+              }
+            ],
+            :voter_classifications => [
+              {:Assertion => "true", :Type => "Other", :OtherType => "citizen"},
+              {:Assertion => "true", :Type => "Other", :OtherType => "resident-of-ontario"}
+            ],
+            :contact_methods => [
+              {:type => "phone", :value => "555-555-5555", :capabilities => ["voice", "fax", "sms"]},
+              {:type => "email", :value => "xyz@gmail.com"}
+            ]
+          }
+        }
+      }
+    }.stringify_keys!
+
+  REGISTRATION_DATA = {
+    :voter_id => "1234",
+    :current_residence => "in",
+    :first_name => "Aaron",
+    :middle_name => "Bernard",
+    :last_name => "Huttner",
+    :name_suffix => "Jr",
+    :phone => "555-555-5555",
+    :gender => "Male",
+    :vvr_address_1 => "123 Walnut",
+    :vvr_county_or_city => "Carleton",
+    :vvr_state => "Ontario",
+    :ma_is_different => "0",
+    :is_confidential_address => "1",
+    :ca_type => "TSC"
+  }
+
+  VRI_ON_NOT_MATCH_RESPONSE =
+    JSON.parse('{"voter_records_response": { "registration_rejection" : {"error" : "no-match" }}}')
+
+  describe 'to_registration' do
+  subject { VriAdapter.new(response).to_registration }
+
+
+  context 'match response' do
+    let(:response) { VRI_ON_MATCH_RESPONSE }
+
+    it 'accepts match response' do
+      expect(subject).to be_instance_of(Registration)
+      expect(subject.data).to include(REGISTRATION_DATA)
+    end
+  end
+
+  context 'match response' do
+    let(:response) { VRI_ON_NOT_MATCH_RESPONSE }
+
+    it 'raises error' do
+      expect { subject }.to raise_error(LookupApi::RecordNotFound)
+    end
+  end
+  end
+end


### PR DESCRIPTION
* added GeneralRegistrationSearch: invoked when id_and_locality_style == false
* added VriAdapter to convert VRI-ON response to Registration
* General lookup does a parameterless request to config['lookup']['url'] - by default points to https://vri-on-stub.herokuapp.com/lookup (stub implementation, autodeployed from https://github.com/vchervanev/vri-stub) and parse response using VriAdapter
* added tests, however current SearchQuery implementation doesn't allow to mock a complete environment - AppConfig values are loaded on app start (config.ru), then SearchQuery is initialized using "conditional attributes" - so we can't switch configs in test environment